### PR TITLE
Save second edit

### DIFF
--- a/web/javascript/event-bus.js
+++ b/web/javascript/event-bus.js
@@ -35,7 +35,6 @@
     var notes = fetchNotes();
     notes.push(note);
     localStorage.setItem(notesKey, JSON.stringify(notes));
-    return true;
   });
 
   EventBus.addListener('update-note', function(changedNote) {
@@ -48,6 +47,5 @@
       }
     });
     localStorage.setItem(notesKey, JSON.stringify(notes));
-    return true;
   });
 })();


### PR DESCRIPTION
Previously the second edit wouldn't save correctly. Removing return true
keeps the event handler attached to the event.

See #8.
